### PR TITLE
Export locals_without_parens for elixir formatter

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,7 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  export: [
+    locals_without_parens: [spec_and_callback: 1]
+  ]
 ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,6 @@ before_script:
 
 script:
   - MIX_ENV=test mix dialyzer --halt-exit-status
+  - mix format --check-formatted
+  - (cd example && mix format --check-formatted)
   - mix test

--- a/example/.formatter.exs
+++ b/example/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:behaves_like]
 ]

--- a/example/lib/api.ex
+++ b/example/lib/api.ex
@@ -6,6 +6,7 @@ defmodule Example.API do
   @type error :: any()
 
   spec_and_callback get(id) :: {:ok, result} | {:error, error}
+
   def get(id) do
     Example.Backend.get(id)
   end

--- a/example/mix.exs
+++ b/example/mix.exs
@@ -19,7 +19,7 @@ defmodule Example.MixProject do
   defp deps do
     [
       {:behaves_like, path: ".."},
-      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}
     ]
   end
 

--- a/example/test/example_test.exs
+++ b/example/test/example_test.exs
@@ -3,20 +3,19 @@ defmodule ExampleTest do
 
   test "specs to callbacks" do
     assert {:ok,
-     [
-       {{:get, 1},
-        [
-          {:type, 8, :fun,
-           [
-             {:type, 8, :product, [{:user_type, 8, :id, []}]},
-             {:type, 8, :union,
-              [
-                {:type, 0, :tuple, [{:atom, 0, :ok}, {:user_type, 8, :result, []}]},
-                {:type, 0, :tuple,
-                 [{:atom, 0, :error}, {:user_type, 8, :error, []}]}
-              ]}
-           ]}
-        ]}
-     ]} = Code.Typespec.fetch_callbacks(Example.API)
+            [
+              {{:get, 1},
+               [
+                 {:type, 8, :fun,
+                  [
+                    {:type, 8, :product, [{:user_type, 8, :id, []}]},
+                    {:type, 8, :union,
+                     [
+                       {:type, 0, :tuple, [{:atom, 0, :ok}, {:user_type, 8, :result, []}]},
+                       {:type, 0, :tuple, [{:atom, 0, :error}, {:user_type, 8, :error, []}]}
+                     ]}
+                  ]}
+               ]}
+            ]} = Code.Typespec.fetch_callbacks(Example.API)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule BehavesLike.MixProject do
       dialyzer: dialyzer(),
       description: "Automatically creates a behaviour from a module's specs.",
       package: package(),
-      docs: docs(),
+      docs: docs()
     ]
   end
 
@@ -39,15 +39,19 @@ defmodule BehavesLike.MixProject do
   end
 
   defp package do
-    [maintainers: ["Michael Shapiro"],
-     licenses: ["MIT"],
-     links: %{"GitHub": "https://github.com/koudelka/behaves_like"}]
+    [
+      maintainers: ["Michael Shapiro"],
+      licenses: ["MIT"],
+      links: %{GitHub: "https://github.com/koudelka/behaves_like"}
+    ]
   end
 
   defp docs do
-    [extras: ["README.md"],
-     source_url: "https://github.com/koudelka/behaves_like",
-     source_ref: @version,
-     main: "readme"]
+    [
+      extras: ["README.md"],
+      source_url: "https://github.com/koudelka/behaves_like",
+      source_ref: @version,
+      main: "readme"
+    ]
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -12,7 +12,9 @@ defmodule BehavesLike.IntegrationTest do
   end
 
   defp mix(task, cd) when is_list(task) do
-    {_, exit_code} = System.cmd("mix", task, cd: cd, env: [{"MIX_ENV", "test"}], into: IO.stream(:stdio, 1))
+    {_, exit_code} =
+      System.cmd("mix", task, cd: cd, env: [{"MIX_ENV", "test"}], into: IO.stream(:stdio, 1))
+
     assert exit_code == 0
   end
 


### PR DESCRIPTION
This makes is so calls to the `spec_and_callback/1` macro won't be automatically be wrapped in parentheses if the user sets up `import_deps: [:behaves_like]` in their `.formatter.exs`. I also ran mix format across both the main behaves_like repo and the example repo to ensure this works. Finally, I added `mix format --check-formatted` to both the main an example repo so you'll know if this formatting check were to break for some reason.